### PR TITLE
Fixing manifest file path.

### DIFF
--- a/services/ElixirService.php
+++ b/services/ElixirService.php
@@ -77,7 +77,7 @@ class ElixirService extends BaseApplicationComponent
      */
     protected function readManifestFile()
     {
-        $manifest = file_get_contents(CRAFT_BASE_PATH . $this->publicPath . '/' . $this->buildPath . '/rev-manifest.json');
+        $manifest = file_get_contents(CRAFT_BASE_PATH . '../' . $this->publicPath . '/' . $this->buildPath . '/rev-manifest.json');
 
         return json_decode($manifest, true);
     }


### PR DESCRIPTION
According to the docs and by default, CRAFT_BASE_PATH is the /craft folder. We need to go back a directory to get to the project root from the Craft folder.
